### PR TITLE
Change the template so that price information is omitted if price is …

### DIFF
--- a/.vuepress/components/Event/TicketsLink.vue
+++ b/.vuepress/components/Event/TicketsLink.vue
@@ -8,7 +8,7 @@
   <div class="ticket--container">
     <!-- Ticket price -->
     <span class="ticket--price">
-      Cost:&nbsp;{{ price }}
+      {{ price }}
     </span>
 
     <!-- Link to ticket sale -->
@@ -30,10 +30,13 @@ export default {
   computed: {
     price () {
       let price = this.$page.frontmatter.price
-      if (!price || price === 0) {
-        return 'Free'
+      if (!price) {
+        return ''
       }
-      price += ' €'
+      if (price === 0) {
+        return 'Cost: Free'
+      }
+      price = 'Cost: ' + price + ' €'
       return price
     }
   }


### PR DESCRIPTION
…not explicitly set.  It can still be set to 0 if we want to indicate the event is free.  In most cases however, pricing is layered so we want to refer to the site.