### PR TITLE
Correct date for DeFi, Scaling, and Drinks event

### DIFF
--- a/events/defi-scaling-and-drinks-0x-balancer-matter-labs-and-optimism/README.md
+++ b/events/defi-scaling-and-drinks-0x-balancer-matter-labs-and-optimism/README.md
@@ -57,7 +57,7 @@ synopsis:
 
 # The date should be in the format year-month-day (ISO 8601).
 # Example: 2018-02-28
-date: 2022-04-21
+date: 2022-04-22
 # The date when the event ends. Can be left empty or set to the same day the
 # event starts.
 endDate:


### PR DESCRIPTION
Hi - I'm from the 0x Labs team. I realized I submitted the wrong date in the form. 
Correcting the date from 4/21 -> 4/22. Eventbrite link with date listed [here](https://www.eventbrite.com/e/defi-scaling-and-drinks-0x-balancer-matter-labs-and-optimism-tickets-317698704377). Thanks!
